### PR TITLE
Mojo2 primitives vertexcolor

### DIFF
--- a/modules/mojo2/cerberusdoc/graphics.cerberusdoc
+++ b/modules/mojo2/cerberusdoc/graphics.cerberusdoc
@@ -589,6 +589,7 @@ Set blend mode. The @blendMode parameter should be one of:
 | BlendMode.Alpha	| Alpha blending
 | BlendMode.Additive	| Additive blending
 | BlendMode.Multiply	| Multiply blending
+| BlendMode.Alpha2	| Alpha blending for non-premultiplied images
 
 
 # Method BlendMode:Int() Property

--- a/modules/mojo2/cerberusdoc/graphics.cerberusdoc
+++ b/modules/mojo2/cerberusdoc/graphics.cerberusdoc
@@ -794,6 +794,26 @@ If @material is null, the current default material is used.
 See also: [[SetDefaultMaterial]]
 
 
+# Method DrawPrimitives:Void( order:Int,count:int,vertices:Float[],texcoords:float[],vertcols:int[],material:Material=Null )
+
+Draw a batch of primtives.
+
+@order is the number of vertices for each primitive, eg: 1 for points, 2 for lines, 3 for triangles etc.
+
+@count is the number of primitives to draw.
+
+The @vertices array contains x,y vertex data, and must be at least @count \* @order \* 2 long.
+
+The @texcoords array contains s,t texture coordinate data, and must be at least @count \* @order \* 2 long.
+
+The @vertcols array contains *abgr* (rgba in reverse order) vertex color data, and must be at least @count \* @order long.
+Remember to always set alpha. Also, if alpha is not 100\% (0xFF), rgb components have to be multiplied, e.g. white (0xFFFFFFFF) becomes gray (0x80808080) when 50\% transparent. Otherwise bleeding will occur when blending with BlendMode.Alpha.
+
+If @material is null, the current default material is used.
+
+See also: [[SetDefaultMaterial]]
+
+
 # Method DrawIndexedPrimitives:Void( order:Int,count:int,vertices:Float[],indices:Int[],material:Material=Null )
 
 Draw a batch of indexed primtives.
@@ -822,6 +842,28 @@ Draw a batch of indexed primtives.
 The @vertices array contains x,y vertex data.
 
 The @texcoords array contains s,t texture coordinate data.
+
+The @indices array contains vertex indices, and must be at least @count \* @order long.
+
+If @material is null, the current default material is used.
+
+See also: [[SetDefaultMaterial]]
+
+
+# Method DrawIndexedPrimitives:Void( order:Int,count:int,vertices:Float[],texcoords:float[],vertcols:int[],indices:Int[],material:Material=Null )
+
+Draw a batch of indexed primtives.
+
+@order is the number of vertices for each primitive, eg: 1 for points, 2 for lines, 3 for triangles etc.
+
+@count is the number of primitives to draw.
+
+The @vertices array contains x,y vertex data.
+
+The @texcoords array contains s,t texture coordinate data.
+
+The @vertcols array contains *abgr* (rgba in reverse order) vertex color data, and must be at least @count \* @order long.
+Remember to always set alpha. Also, if alpha is not 100\% (0xFF), rgb components have to be multiplied, e.g. white (0xFFFFFFFF) becomes gray (0x80808080) when 50\% transparent. Otherwise bleeding will occur when blending with BlendMode.Alpha.
 
 The @indices array contains vertex indices, and must be at least @count \* @order long.
 

--- a/modules/mojo2/graphics.cxs
+++ b/modules/mojo2/graphics.cxs
@@ -1506,6 +1506,8 @@ Class BlendMode
 	Const Additive:=2
 	Const Multiply:=3
 	Const Multiply2:=4
+' 20180208, Holzchopf - ADDED Alpha2 for non-premultiplied images
+	Const Alpha2:=5
 End
 
 Class DrawList
@@ -2132,6 +2134,10 @@ Class DrawList
 			Case .BlendMode.Multiply2
 				glEnable GL_BLEND
 				glBlendFunc GL_DST_COLOR,GL_ZERO
+' 20180208, Holzchopf - ADDED Alpha2 for non-premultiplied images
+			Case .BlendMode.Alpha2
+				glEnable GL_BLEND
+				glBlendFunc GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA
 			End
 		End
 		

--- a/modules/mojo2/graphics.cxs
+++ b/modules/mojo2/graphics.cxs
@@ -1762,6 +1762,26 @@ Class DrawList
 		Next
 	End
 	
+' 20180218, Holzchopf - ADDED drawing primitives with individual vertex color
+	Method DrawPrimitives:Void( order:Int,count:Int,vertices:Float[],texcoords:Float[],vertcols:Int[],material:Material=Null )
+		' save current color for later
+		Local tmpcolor := _pmcolor
+		' draw primitives
+		BeginPrims material,order,count
+		Local p:=0
+		For Local i:=0 Until count
+			For Local j:=0 Until order
+				' write vertex color
+				_pmcolor = vertcols[i*order+j]
+				' write vertex data
+				PrimVert vertices[p],vertices[p+1],texcoords[p],texcoords[p+1]
+				p+=2
+			Next
+		Next
+		' restoree color
+		_pmcolor = tmpcolor
+	End
+	
 	Method DrawIndexedPrimitives:Void( order:Int,count:Int,vertices:Float[],indices:Int[],material:Material=Null )
 	
 		BeginPrims material,order,count
@@ -1788,6 +1808,31 @@ Class DrawList
 			p+=order
 		Next
 	
+	End
+	
+' 20180218, Holzchopf - ADDED drawing primitives with individual vertex color
+	Method DrawIndexedPrimitives:Void( order:Int,count:Int,vertices:Float[],texcoords:Float[],vertcols:Int[],indices:Int[],material:Material=Null )
+		' save current color for later
+		Local tmpcolor := _pmcolor
+		' draw primitives
+		BeginPrims material,order,count
+		Local p:=0
+		Local v:Int		' vertex index
+		Local k:Int		' index in vertices array
+		For Local i:=0 Until count
+			For Local j:=0 Until order
+				' index
+				v = indices[p+j]
+				k = v*2
+				' write vertex color
+				_pmcolor = vertcols[v]
+				' write vertex data
+				PrimVert vertices[k],vertices[k+1],texcoords[k],texcoords[k+1]
+			Next
+			p+=order
+		Next
+		' restoree color
+		_pmcolor = tmpcolor
 	End
 	
 	Method DrawRect:Void( x0:Float,y0:Float,width:Float,height:Float,material:Material=Null,s0:Float=0,t0:Float=0,s1:Float=1,t1:Float=1 )


### PR DESCRIPTION
Added methods DrawPrimitives and DrawIndexedPrimitives to DrawList which allow to draw primitives with per-vertex colouring.