### PR TITLE
Feature character literals

### DIFF
--- a/modules/trans/config.cxs
+++ b/modules/trans/config.cxs
@@ -192,7 +192,8 @@ End
 Function Dequote$( str$,lang$ )
 	Select lang
 		Case "cerberus"
-			If str.Length<2 Or Not str.StartsWith("~q") Or Not str.EndsWith("~q") InternalErr
+			If str.Length<2 Or (Not (str.StartsWith("~q") And str.EndsWith("~q")) And Not(str.StartsWith("`") And str.EndsWith("`"))) InternalErr
+			Local isChar:=str.StartsWith("`")
 			str=str[1..-1]
 			Local i:=0
 			Repeat
@@ -206,6 +207,7 @@ Function Dequote$( str$,lang$ )
 					Case "n" ch="~n"
 					Case "r" ch="~r"
 					Case "t" ch="~t"
+					Case "b" ch="`"
 					Case "u"
 						Local t:=str[i+2..i+6]
 						If t.Length<>4 Err "Invalid unicode hex value in string"
@@ -222,9 +224,11 @@ Function Dequote$( str$,lang$ )
 				str=str[..i]+ch+str[i+2..]
 				i+=ch.Length
 			Forever
+			If isChar And str.Length>1 InternalErr
 			Return str
 		Case "monkey" 'backwards compatibility
-			If str.Length<2 Or Not str.StartsWith("~q") Or Not str.EndsWith("~q") InternalErr
+			If str.Length<2 Or (Not (str.StartsWith("~q") And str.EndsWith("~q")) And Not(str.StartsWith("`") And str.EndsWith("`"))) InternalErr
+			Local isChar:=str.StartsWith("`")
 			str=str[1..-1]
 			Local i:=0
 			Repeat
@@ -238,6 +242,7 @@ Function Dequote$( str$,lang$ )
 					Case "n" ch="~n"
 					Case "r" ch="~r"
 					Case "t" ch="~t"
+					Case "b" ch="`"
 					Case "u"
 						Local t:=str[i+2..i+6]
 						If t.Length<>4 Err "Invalid unicode hex value in string"
@@ -254,6 +259,7 @@ Function Dequote$( str$,lang$ )
 				str=str[..i]+ch+str[i+2..]
 				i+=ch.Length
 			Forever
+			If isChar And str.Length>1 InternalErr
 			Return str
 	End
 	InternalErr

--- a/modules/trans/config.cxs
+++ b/modules/trans/config.cxs
@@ -207,7 +207,7 @@ Function Dequote$( str$,lang$ )
 					Case "n" ch="~n"
 					Case "r" ch="~r"
 					Case "t" ch="~t"
-					Case "b" ch="`"
+					Case "g" ch="`"
 					Case "u"
 						Local t:=str[i+2..i+6]
 						If t.Length<>4 Err "Invalid unicode hex value in string"
@@ -242,7 +242,7 @@ Function Dequote$( str$,lang$ )
 					Case "n" ch="~n"
 					Case "r" ch="~r"
 					Case "t" ch="~t"
-					Case "b" ch="`"
+					Case "g" ch="`"
 					Case "u"
 						Local t:=str[i+2..i+6]
 						If t.Length<>4 Err "Invalid unicode hex value in string"

--- a/modules/trans/expr.cxs
+++ b/modules/trans/expr.cxs
@@ -162,6 +162,9 @@ Class ConstExpr Extends Expr
 				value=StringToInt( value[1..],2 )
 			Else If value.StartsWith( "$" )
 				value=StringToInt( value[1..],16 )
+			Else If value.StartsWith( "`" ) And value.EndsWith( "`" )
+				value=Dequote(value, "cerberus")
+				If value.Length<1 value=0 Else value=value[0]
 			Else
 				'strip leading 0's or we can end up with an octal const!
 				While value.Length>1 And value.StartsWith( "0" )

--- a/modules/trans/toker.cxs
+++ b/modules/trans/toker.cxs
@@ -17,6 +17,7 @@ Const TOKE_STRINGLIT=6
 Const TOKE_STRINGLITEX=7
 Const TOKE_SYMBOL=8
 Const TOKE_LINECOMMENT=9
+Const TOKE_INTLITEX=10
 
 '***** Tokenizer *****
 Class Toker
@@ -164,6 +165,12 @@ Class Toker
 				_tokePos+=1
 			Wend
 			If _tokePos<_length _tokePos+=1 Else _tokeType=TOKE_STRINGLITEX
+		Else If str="`"
+			_tokeType=TOKE_INTLIT
+			While _tokePos<_length And TSTR()<>"`"
+				_tokePos+=1
+			Wend
+			If _tokePos<_length _tokePos+=1 Else _tokeType=TOKE_INTLITEX
 		Else If str="'"
 			_tokeType=TOKE_LINECOMMENT
 			While _tokePos<_length And TSTR()<>"~n"


### PR DESCRIPTION
Added character literals and added an escape character '~g' (for grave accent since '~b' could be mistaken for backspace instead of backtick).