### PR TITLE
Check to see if asyncevent is active

### DIFF
--- a/modules/brl/asyncevent.cxs
+++ b/modules/brl/asyncevent.cxs
@@ -30,3 +30,10 @@ Function UpdateAsyncEvents()
 	Wend
 	_current=Null
 End
+
+Function AsyncActive:Bool()
+	If _sources.Length() >= 1
+		Return True
+	End If
+	Return False
+End Function


### PR DESCRIPTION
 Useful to prevent the screen from fading out until everything is loaded in