### PR TITLE
Few changes to makedocs + some .cerberusdoc updates

### DIFF
--- a/docs/cerberusdoc/Tools/Makedocs.cerberusdoc
+++ b/docs/cerberusdoc/Tools/Makedocs.cerberusdoc
@@ -55,11 +55,11 @@ All generated html files are written in `docs/html/`, that's why the relative pa
 
 >> <a name="general"></a> General documentation
 
-General documentation files have a `.cerberusdoc` extension and are placed in the `docs/cerberusdoc/` directory or subdirectories therein. Makedocs will automatically create index files for directories without matching `.cerberusdoc` file and in there, list the contents of that directory.
+General documentation files have a `.cerberusdoc` extension and are placed in the `docs/cerberusdoc/` directory or subdirectories therein. Makedocs will automatically create index files for directories without matching `.cerberusdoc` file and in there, list the contents of that directory. 
 
 The landing page for the Cerberus X documentation is `Home.cerberusdoc`.
 
-For backwards compatibility, the `.monkeydoc` extension is treated like the `.cerberusdoc` extension.
+For backwards compatibility, the `.monkeydoc` extension is treated like the `.cerberusdoc` extension. The files must be UTF-8 encoded - IDEs such as [[Ted]] automatically use this encoding, but other text editors might not.
 
 
 >> <a name="module"></a> Module documentation
@@ -107,7 +107,7 @@ Following declarations will show up in the docs.
 #End
 </pre>
 
-For backwards compatibility, the `.monkey` extension is treated like the `.cxs` extension.
+For backwards compatibility, the `.monkey` extension is treated like the `.cxs` extension. The files must be UTF-8 encoded - IDEs such as [[Ted]] automatically use this encoding, but other text editors might not.
 
 
 >>> Documenting modules using an external cerberusdoc file
@@ -145,7 +145,7 @@ Documentation for my.module goes here.
 Documentation for MyFunction goes here.</code>
 </div>
 
-For backwards compatibility, the `.monkeydoc` extension is treated like the `.cerberusdoc` extension and the `monkeydoc` directory like the `cerberusdoc` one.
+For backwards compatibility, the `.monkeydoc` extension is treated like the `.cerberusdoc` extension and the `monkeydoc` directory like the `cerberusdoc` one. The files must be UTF-8 encoded - IDEs such as [[Ted]] automatically use this encoding, but other text editors might not.
 
 
 >>> Adding examples to declarations

--- a/docs/cerberusdoc/Tools/Makedocs/Makedocs templates.cerberusdoc
+++ b/docs/cerberusdoc/Tools/Makedocs/Makedocs templates.cerberusdoc
@@ -37,12 +37,19 @@ For this file, Makedocs provides the following lists and fields:
 | Name			| Description
 | `CONTENT`		| Page content passed on by scope_template, index_template or plain markdown from general documentation.
 | `ICONLINKS`	| List of all icon links (links to 3rd party docs)
-| &emsp;`ICON`	| Image source for that icon link
-| &emsp;`URL`	| Target url for that icon link
 | `NAVLINKS`	| List of navigation links (current location)
-| &emsp;`IDENT`	| Name of navigation link
-| &emsp;`URL`	| Url of that link
 
+In `ICONLINKS`, these fields are available:
+
+| Name			| Description
+| `ICON`		| Image source for that icon link
+| `URL`			| Target url for that icon link
+
+In `NAVLINKS`, these fields are available:
+
+| Name			| Description
+| `IDENT`		| Name of navigation link
+| `URL`			| Url of that link
 
 >> The scope_template.html File
 
@@ -110,11 +117,12 @@ For classes and interfaces, these lists are available:
 
 >> The index_template.html File
 
-Makedocs automatically generates some indexes, e.g. of all modules and also for folders that have no corresponding %.cerberusdoc% file. For indexes, two additional fields are provided:
+Makedocs automatically generates some indexes, e.g. of all modules and also for folders that have no corresponding %.cerberusdoc% file. For indexes, three additional fields are provided:
 
-| Name			| Description
-| `INDEX`		| Name of that index
-| `ITEMS`		| List of all declarations in that index
+| Name				| Description
+| `INDEX`			| Name of that index
+| `ITEMS`			| List of all declarations in that index
+| `INDEX_SHORTCUTS`	| List of the letters a to z for short cuts
 
 Since indexes can also list general documentation, only basic fields that can be retrieved from every type of documentation are provide for the items:
 
@@ -123,3 +131,9 @@ Since indexes can also list general documentation, only basic fields that can be
 | `URL`			| Url for that declaration / page
 | `SCOPE`		| Scope of this declaration / page
 | `SUMMARY`		| Summary field
+
+`INDEX_SHORTCUTS` provides the following fields:
+
+| Name			| Description
+| `IDENT`		| The short cut letter (`a` to `z`)
+| `URL`			| Url for the first element in that letter category

--- a/modules/brl/cerberusdoc/markdown.cerberusdoc
+++ b/modules/brl/cerberusdoc/markdown.cerberusdoc
@@ -118,6 +118,8 @@ Function Main:Int()
 End
 </pre>
 
+@Note that inside `\<pre\>` blocks markdown is bypassed, so you don't have to escape html or markdown special chars.
+
 For code blocks without syntax highlighting, you need to use in-line html with `\<div class="pretty"\> .. \</div\>` tags around the block and put the code into `\<code\> .. \</code\>` tags. However, the escaping within such blocks differs from the one within pre-tags, meaning you have to escape html characters and markdown. Also, such blocks *may not* contain blank lines, since they will be translated into paragraph separators, which would cause invalid html. Instead, you have to put a space character at the place of a blank line.
 
 

--- a/modules/mojo/cerberusdoc/app.cerberusdoc
+++ b/modules/mojo/cerberusdoc/app.cerberusdoc
@@ -263,10 +263,10 @@ Class MyApp Extends App
 	Method OnUpdate()
 	
 		If MouseHit(0)
-			If MouseY()\<DeviceHeight/2
+			If MouseY()<DeviceHeight/2
 				OpenUrl "http://www.cerberus-x.com"
 			Else
-				OpenUrl "mailto:martin.leidel@gmail.com"
+				OpenUrl "mailto:email@example.com"
 			Endif
 		Endif
 	End
@@ -274,7 +274,7 @@ Class MyApp Extends App
 	Method OnRender()
 	
 		Cls
-		DrawText "Click above to visit Cerberus X, below to email Martin!",DeviceWidth/2,DeviceHeight/2,.5,.5
+		DrawText "Click above to visit Cerberus X, below to email some one!",DeviceWidth/2,DeviceHeight/2,.5,.5
 	End
 
 End

--- a/src/makedocs/apidoccer.cxs
+++ b/src/makedocs/apidoccer.cxs
@@ -314,7 +314,7 @@ Class ApiDoccer
 				Local state := parser.Store()
 				parser.NextSpace()
 				' start of a rem block
-				If parser.NextCdata("#Rem") Then
+				If parser.NextCdata("#rem", True) Then
 					parser.NextToke()
 					' only analyse first level rem blocks
 					' (not already in a block)
@@ -367,7 +367,7 @@ Class ApiDoccer
 					End
 				' start of another precompiler conditional block
 				' (count them too as they're terminated with #End as well)
-				Elseif parser.NextCdata("#If") Then
+				Elseif parser.NextCdata("#if", True) Then
 					If indoc Then
 						parser.Restore( state )
 						Local str:String = parser.NextRestOfLine()
@@ -378,7 +378,7 @@ Class ApiDoccer
 						docblocks.Push( BLOCK_CONDITION )
 					End
 				' end of a contitional block
-				Elseif parser.NextCdata("#End") Then
+				Elseif parser.NextCdata("#end", True) Then
 					docblocks.Pop()
 					If docblocks.Length() > 0 And docblocks.Get(0) = BLOCK_DOC Then
 						parser.Restore( state )
@@ -410,6 +410,14 @@ Class ApiDoccer
 									' send through Add to match parent
 									curdecl.Add( d )
 								Next
+								' if decl was a whole list, copy documentation
+								' to other set elements
+								If parser.listofdecls Then
+									' remove curdecl - that one is already docced
+									parser.listofdecls.RemoveEach( curdecl )
+									' copy documentation to rest in list
+									_CopyDoccDecl( doccdecl, parser.listofdecls )
+								End
 								doccdecl = Null
 							End
 						End
@@ -469,6 +477,16 @@ Class ApiDoccer
 			' Windows (CR+LF) and Mac line endings (CR) to Unix ones
 			curparagraph.ident += UnifyLineEndings( pString )
 		End
+	End
+	
+	' copy the childs from pDoccDecl to all decls in pDecls
+	Method _CopyDoccDecl:Void( pDoccDecl:DocDecl, pDecls:Stack<DocDecl> )
+		For Local ld := Eachin pDecls
+			For Local d := Eachin pDoccDecl.childs
+				' Add copy of existing doccdecl
+				ld.Add( New DocDecl( d.kind, d.ident ) )
+			Next
+		Next
 	End
 	
 	' apply the template loaded in pPager to a module like pDecl
@@ -574,8 +592,12 @@ Class ApiDoccer
 		pPager.SetString("URL", maker.BuildDocLink( tdecl ) )
 		' SCOPE - the scope that uniquely identifies this decl at global
 		pPager.SetString("SCOPE", tdecl.GetScopeIdent() )
-		' SUMMARY, markdowned 
-		txt = tdecl.GetTextOfChild( DECL_SUMMARY )
+		' SUMMARY, markdowned
+		If tdecl.kind = DECL_ENUM_ELEMENT Then
+			txt = tdecl.parent.GetTextOfChild( DECL_SUMMARY )
+		Else
+			txt = tdecl.GetTextOfChild( DECL_SUMMARY )
+		End
 		txt = StripParagraph( maker.marker.ToHtml(txt) )
 		pPager.SetString("SUMMARY", txt )
 		' fields only for CX declarations

--- a/src/makedocs/makedocs.cxs
+++ b/src/makedocs/makedocs.cxs
@@ -24,6 +24,13 @@ makedocs.exe -ignore "brl.admob;reflection"
 
 Changelog (REMEMBER CONST <<VERSION>> WHEN CHANGING)
 --------------------------------------------------------------------------------
+2019-01-15 - Holzchopf
+	- FIXED precompiler directives are now parsed "case insensitive"
+	- CHANGED decls.txt format is now
+		KIND;IDENTIFIER;SCOPE;STATUS
+	- CHANGED descriptions and summaries are now provided for every element in
+		a decl list (as in Field x:Int, y:Int, z:Int)
+	- CHANGED ENUM_ELEMENTS now take the summary from their parent ENUM
 2019-01-08 - Holzchopf
 	- ADDED list ${INDEX_SHORTCUTS}: List of A...Z linking to the first matching
 		anchor in the index, available in indexes. List containing of:
@@ -91,7 +98,7 @@ Import apidoccer
 Import docdoccer
 
 '===============================================================================
-Const VERSION:String		= "2019-01-08"
+Const VERSION:String		= "2019-01-15"
 '===============================================================================
 
 ' path settings
@@ -985,16 +992,31 @@ Class Makedocs Implements ILinkResolver, IPrettifier
 		SaveString( txt, PATH_HTML_BASE + "/index.txt" )
 		' make decls.txt
 		' decls.txt format:
-		' KIND FULLIDENTIFIER;URL;PATHTODECLARATION
+		' KIND;IDENTIFIER;SCOPE;STATUS;
 		txt = ""
 		For Local d := Eachin alldecls
 			Local ktxt:String = d.GetKindName()
 			If ktxt <> "Unspecified" Then
-				Local str := d.GetScopeIdent() + d.ident + d.GetDocType().Replace(" ","")
-				txt += ktxt + " " + str
-				txt += ";" + BuildDocLink( d )
-				txt += ";"
-				txt += "~n"
+				Local str := ktxt + ";"
+				str += d.ident + ";"
+				' strip trailing "." from scope
+				Local stxt := d.GetScopeIdent()
+				If stxt.EndsWith(".") Then
+					stxt = stxt[..-1]
+				End
+				str += stxt + ";"
+				Local dtxt:String
+				' "decl" string comes either from decl itself, or from targeted
+				' decl (e.g. for inherited methods)
+				If d.target Then
+					dtxt = d.target.GetDocType()
+				Else
+					dtxt = d.GetDocType()
+				End
+				' escape ";" with "~s" and "~" with "~~"
+				dtxt = dtxt.Replace("~~","~~~~").Replace(";","~~s")
+				str += d.ident + dtxt + ";"
+				txt += str + "~n"
 			End
 		Next
 		SaveString( txt, PATH_HTML_BASE + "/decls.txt" )

--- a/src/makedocs/parser.cxs
+++ b/src/makedocs/parser.cxs
@@ -108,7 +108,8 @@ Class Parser Extends Toker
 	End
 	
 	' instead of a token, this thing only eats when matching CDATA
-	Method NextCdata:String( pString:String )
+	' pCaseInsensitive=True will ignore case
+	Method NextCdata:String( pString:String, pCaseInsensitive:Bool=False )
 		_toke = ""
 		' source end reached
 		If _tokePos = _length Then
@@ -119,7 +120,8 @@ Class Parser Extends Toker
 		If _tokePos + ln < _length Then
 			Local sstr:String = _source[_tokePos .. _tokePos+ln]
 			' match
-			If sstr = pString Then
+			If sstr = pString Or
+			(pCaseInsensitive And sstr.ToLower() = pString.ToLower()) Then
 				_toke = sstr
 				_tokeType = TOKE_CDATA
 				_tokePos += ln
@@ -262,9 +264,15 @@ Class Parser Extends Toker
 	'---------------------------------------------------------------------------
 	' ParseXXX methods return a DocDecl node or null if not successful
 	' the generated DocDecl node is automatically appended to pScope
+
+	' Some Parse* methods can result in whole lists, but can only return one
+	' item thereof. In that case, the complete list will be stored in this:
+	Field listofdecls:Stack<DocDecl>
 	
 	' parse a declaration in pScope
 	Method ParseDecl:DocDecl( pScope:DocDecl )
+		' only needed for parsing lists of decls
+		listofdecls = Null
 		' valid declarations start with...
 		Select _toke.ToLower()
 		Case "module"
@@ -310,6 +318,10 @@ Class Parser Extends Toker
 				If ltoke = "const" Then kind = DECL_CLASSCONST
 				If ltoke = "global" Then kind = DECL_CLASSGLOBAL
 				Local decls := ParseVariableSet( scope, kind )
+				' provide whole list of vars
+				If decls.Length > 1 Then
+					listofdecls = decls
+				End
 				Return decls.Get(0)
 			' otherwise it's at module scope
 			Else
@@ -318,6 +330,10 @@ Class Parser Extends Toker
 				If ltoke = "const" Then kind = DECL_CONST
 				If ltoke = "global" Then kind = DECL_GLOBAL
 				Local decls := ParseVariableSet( scope, kind )
+				' provide whole list of vars
+				If decls.Length > 1 Then
+					listofdecls = decls
+				End
 				Return decls.Get(0)
 			End
 		Case "enumerate"
@@ -344,6 +360,10 @@ Class Parser Extends Toker
 			Local scope := GetClassScope( pScope )
 			If scope Then
 				Local decls := ParseVariableSet( scope, DECL_FIELD )
+				' provide whole list of vars
+				If decls.Length > 1 Then
+					listofdecls = decls
+				End
 				Return decls.Get(0)
 			Else
 				Error("Field declaration must be at class scope")
@@ -587,7 +607,7 @@ Class Parser Extends Toker
 	End
 	
 	' parses a set of variables
-	' e.g. 'Global' a:Int, b:Int
+	' e.g. Global a:Int, b:Int
 	Method ParseVariableSet:Stack<DocDecl>( pScope:DocDecl, pKind:Int )
 		Local decls := New Stack<DocDecl>
 		' could be a whole list, so loop


### PR DESCRIPTION
FIXED precompiler directives are now parsed "case insensitive"
CHANGED decls.txt format is now
	KIND;IDENTIFIER;SCOPE;STATUS
CHANGED descriptions and summaries are now provided for every element in
	a decl list (as in Field x:Int, y:Int, z:Int)
CHANGED ENUM_ELEMENTS now take the summary from their parent ENUM

UPDATED some .cerberusdoc documentation
	Makedocs
	Makedocs/Makedocs templates